### PR TITLE
Add fatal error for backend sync class definitions

### DIFF
--- a/docs/manual/02 Cross-Realm Imports.md
+++ b/docs/manual/02 Cross-Realm Imports.md
@@ -32,7 +32,7 @@ console.log(await getData()); // [1,2,3]
 > [!WARNING]
 > The following values have limitations when they are imported as backend exports from the frontend:
 > * Classes 
->   * Class definitions should always be put in `common` module if the class is used both on the backend and frontend.
+>   * Class definitions should always be put in a `common` module if the class is used both on the backend and frontend.
 >   * static class fields can still be accessed on a class imported from the backend
 > * Symbols exported from a backend module cannot be imported in a frontend module
 


### PR DESCRIPTION
`@sync` classes from a backend module cannot be used in frontend modules for now. Currently, there is no error indicating that this is forbidden. Instead we get a circular import and nothing happens at all. This is a bad developer experience.

With this PR, we now show an error message in the browser console when trying to load a backend module containing a sync class from the frontend.

Depends on https://github.com/unyt-org/datex-core-js-legacy/pull/30/commits/dd8a7dc1f6cd5a28c77cc3f3173212d84cfa759a