### PR TITLE
Disable exposure of native error stack traces via DATEX

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -306,8 +306,11 @@ globalThis.reset = app.reset;
 	}
 })
 
-
-
+if (app.stage !== "dev") {
+	// don't expose native error messages and stack traces via DATEX
+	Datex.Runtime.OPTIONS.NATIVE_ERROR_STACK_TRACES = false
+	Datex.Runtime.OPTIONS.NATIVE_ERROR_MESSAGES = false
+}
 
 bindingOptions.mapFileURL = (url) => {
 	return convertToWebPath(url);

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -307,9 +307,8 @@ globalThis.reset = app.reset;
 })
 
 if (app.stage !== "dev") {
-	// don't expose native error messages and stack traces via DATEX
+	// don't expose native error stack traces via DATEX
 	Datex.Runtime.OPTIONS.NATIVE_ERROR_STACK_TRACES = false
-	Datex.Runtime.OPTIONS.NATIVE_ERROR_MESSAGES = false
 }
 
 bindingOptions.mapFileURL = (url) => {

--- a/src/app/frontend-manager.ts
+++ b/src/app/frontend-manager.ts
@@ -929,8 +929,13 @@ if (!window.location.origin.endsWith(".unyt.app")) {
 				// give pointer read permissions for hydratable nodes to client endpoint
 				if (Datex.Runtime.OPTIONS.PROTECT_POINTERS) {
 					if (hydratableNodes && metadata.endpoint) {
-						for (const node of hydratableNodes) {
-							grantAccess(node, metadata.endpoint.main)
+						try {
+							for (const node of hydratableNodes) {
+								grantAccess(node, metadata.endpoint.main)
+							}
+						}
+						catch (e) {
+							console.error(e);
 						}
 					}
 				}

--- a/src/app/frontend-manager.ts
+++ b/src/app/frontend-manager.ts
@@ -927,11 +927,14 @@ if (!window.location.origin.endsWith(".unyt.app")) {
 				}
 
 				// give pointer read permissions for hydratable nodes to client endpoint
-				if (hydratableNodes && metadata.endpoint) {
-					for (const node of hydratableNodes) {
-						grantAccess(node, metadata.endpoint.main)
+				if (Datex.Runtime.OPTIONS.PROTECT_POINTERS) {
+					if (hydratableNodes && metadata.endpoint) {
+						for (const node of hydratableNodes) {
+							grantAccess(node, metadata.endpoint.main)
+						}
 					}
 				}
+				
 
 				await this.server.serveContent(
 					requestEvent, 

--- a/src/base/decorators.ts
+++ b/src/base/decorators.ts
@@ -47,7 +47,7 @@ function _defaultOptions(url:string, component_class:typeof HTMLElement, name:co
 		// preload css files
 		component_class.preloadStylesheets?.();
 
-		const name = String(component_class.name).split(/([A-Z][a-z]+)/).filter(t=>!!t).map(t=>t.toLowerCase()).join("-"); // convert from CamelCase to snake-case
+		const name = String(component_class.name).replace(/1$/,'').split(/([A-Z][a-z]+)/).filter(t=>!!t).map(t=>t.toLowerCase()).join("-"); // convert from CamelCase to snake-case
 
 		const datex_type = Datex.Type.get("std", "uix", name);
 		const options_datex_type = Datex.Type.get("uixopt", name);

--- a/src/base/theme-manager.ts
+++ b/src/base/theme-manager.ts
@@ -91,6 +91,10 @@ class ThemeManager  {
 		const currentDarkTheme = client_type == "browser" ? (getCookie(UIX_COOKIE.themeDark) ?? "uix-dark") : "uix-dark";
 		const currentLightTheme = client_type == "browser" ? (getCookie(UIX_COOKIE.themeLight) ?? "uix-light") : "uix-light";
 
+		// set default themes (set by cookies)
+		if (this.getTheme(currentDarkTheme)) this.setDefaultDarkTheme(this.getTheme(currentDarkTheme)!);
+		if (this.getTheme(currentLightTheme)) this.setDefaultLightTheme(this.getTheme(currentLightTheme)!);
+
 		// set current theme if not a parsed theme
 		if (currentMode == "dark" && this.getTheme(currentDarkTheme, true)) {
 			this.setTheme(currentDarkTheme, true);

--- a/src/base/theme-manager.ts
+++ b/src/base/theme-manager.ts
@@ -104,7 +104,7 @@ class ThemeManager  {
 		}
 		else {
 			this.#current_mode = currentMode;
-			this.#current_theme = currentDarkTheme;
+			this.#current_theme = currentMode == "dark" ? currentDarkTheme : currentLightTheme;
 		}
 
 		// current server-guessed mode does not match client mode, remember preferred theme to enable if a frontend theme is loaded
@@ -295,7 +295,9 @@ class ThemeManager  {
 		this.#current_theme = theme.name;
 		logger.debug(`using theme "${theme.name}"`)
 
-		setCookie(UIX_COOKIE.themeDark, theme.name);
+		if (!theme.mode || theme.mode == "dark") setCookie(UIX_COOKIE.themeDark, theme.name);
+		else if (!theme.mode || theme.mode == "light") setCookie(UIX_COOKIE.themeLight, theme.name);
+
 		if (theme.mode) setCookie(UIX_COOKIE.colorMode, theme.mode);
 
 		let text = ":root{";

--- a/src/components/Component.ts
+++ b/src/components/Component.ts
@@ -9,7 +9,7 @@ import { Context } from "../routing/context.ts";
 import { makeScrollContainer, scrollContext, scrollToBottom, scrollToTop, updateScrollPosition } from "../standalone/scroll_container.ts";
 import { OpenGraphInformation, OpenGraphPreviewImageGenerator, OPEN_GRAPH } from "../base/open-graph.ts";
 import { bindContentProperties } from "../standalone/bound_content_properties.ts";
-import { DX_IGNORE, INIT_PROPS } from "datex-core-legacy/runtime/constants.ts"
+import { DX_IGNORE, DX_TYPE, DX_ROOT, INIT_PROPS } from "datex-core-legacy/runtime/constants.ts"
 import { PlaceholderCSSStyleDeclaration, addGlobalStyleSheetLink, addStyleSheetLink } from "../utils/css-style-compat.ts";
 import { indent } from "datex-core-legacy/utils/indent.ts"
 import { serializeJSValue } from "../utils/serialize-js.ts";
@@ -1377,6 +1377,13 @@ export abstract class Component<O = Component.Options, ChildElement = JSX.single
 
 }
 
+// construct pseudo @sync class
+const type = Datex.Type.get("uixcomponent")
+Component[DX_TYPE] = type;
+Component[DX_ROOT] = true
+type.setTemplate({
+    options: any
+})
 
 // get object-like keys that need to be cloned from the prototype
 export function getCloneKeys(object:any):Set<string> {

--- a/src/components/Component.ts
+++ b/src/components/Component.ts
@@ -554,6 +554,7 @@ export abstract class Component<O = Component.Options, ChildElement = JSX.single
         // constructor arguments handlded by DATEX @constructor, constructor declaration only for IDE / typescript
         super()
 
+
         // pre-init options before other DATEX state is initialized 
         // (this should not happen when reconstructing, because options are undefined or have [INIT_PROPS])
         if (options && !options[INIT_PROPS]) this.initOptions(options);
@@ -574,6 +575,12 @@ export abstract class Component<O = Component.Options, ChildElement = JSX.single
                 this.is_skeleton = true;
                 this.reconstructed_from_dom = true;
                 logger.debug("hydrating component " + classType);
+                // throw error if option properties are access during class instance member initialization (can't know options at this point)
+                this.options = new Proxy({}, {
+                    get: (target, prop) => {
+                        throw new Error(`Tried to access uninitialized option property '${String(prop)}' during class instance member initialization of hydrated component. Please put the property initialization in the onConstruct() method.`)
+                    }
+                })
             }
             else {
                 this.reconstructed_from_dom = true;

--- a/src/html/entrypoints.ts
+++ b/src/html/entrypoints.ts
@@ -3,7 +3,7 @@ import { Context } from "../routing/context.ts";
 import { Path } from "../utils/path.ts";
 import { HTTPStatus } from "./http-status.ts";
 import { RenderPreset, RenderMethod } from "../base/render-methods.ts";
-import { KEEP_CONTENT } from "./entrypoint-providers.tsx";
+import { FileHandle, KEEP_CONTENT } from "./entrypoint-providers.tsx";
 import { resolveEntrypointRoute } from "../routing/rendering.ts";
 import { filter } from "../routing/route-filter.ts";
 import { Element } from "../uix-dom/dom/mod.ts";
@@ -31,7 +31,7 @@ const a: SharedData = {
 type RefOrValueUnion<U> = (U extends any ? Datex.RefOrValue<U> : never)
 
 export type raw_content = Blob|Response // sent as raw Response
-export type special_content = URL|Deno.FsFile|HTTPStatus|Error // gets converted to a Response
+export type special_content = URL|Deno.FsFile|FileHandle|HTTPStatus|Error // gets converted to a Response
 export type html_content = RefOrValueUnion<JSX.Element|string|number|boolean|bigint|Datex.Markdown|RouteManager|RouteHandler>|null|undefined|raw_content|special_content;
 export type html_content_or_generator<
 	CustomSharedData extends Record<string, unknown>|SharedData = SharedData,

--- a/src/html/render.ts
+++ b/src/html/render.ts
@@ -126,7 +126,7 @@ function _getOuterHTML(el:Node, opts?:_renderOptions, collectedStylesheets?:stri
 
 	// TODO: also for attributes transforms
 	if (opts?.lang) {
-		for (const childPtr of (el as DOMUtils.elWithEventListeners)[DOMUtils.CHILDREN_DX_VALUES]??[]) {
+		for (const childPtr of (el as DOMUtils.elWithUIXAttributes)[DOMUtils.CHILDREN_DX_VALUES]??[]) {
 			if (childPtr.transformSource) {
 				for (const ptr of [...childPtr.transformSource.deps, ...childPtr.transformSource.keyedDeps.keys()]) {
 					if (ptr instanceof Datex.Pointer && ptr.transformMap) {
@@ -247,7 +247,7 @@ function _getOuterHTML(el:Node, opts?:_renderOptions, collectedStylesheets?:stri
 	else attrs.push("uix-static");
 
 	// inject event listeners
-	if (dataPtr && opts?._injectedJsData && ((<DOMUtils.elWithEventListeners>el)[DOMUtils.EVENT_LISTENERS] || (<DOMUtils.elWithEventListeners>el)[DOMUtils.PSEUDO_ATTR_BINDINGS])) {
+	if (dataPtr && opts?._injectedJsData && ((<DOMUtils.elWithUIXAttributes>el)[DOMUtils.EVENT_LISTENERS] || (<DOMUtils.elWithUIXAttributes>el)[DOMUtils.PSEUDO_ATTR_BINDINGS])) {
 		let context: HTMLElement|undefined;
 		let parent: Element|null = el;
 		let hasScriptContent = false; // indicates whether the generated script actually contains relevant content, not just skeleton code
@@ -264,7 +264,7 @@ function _getOuterHTML(el:Node, opts?:_renderOptions, collectedStylesheets?:stri
 		script += `el[EVENT_LISTENERS] ??= new Map();\n`
 
 		// inject listeners
-		for (const [event, listeners] of (<DOMUtils.elWithEventListeners>el)[DOMUtils.EVENT_LISTENERS] ?? []) {
+		for (const [event, listeners] of (<DOMUtils.elWithUIXAttributes>el)[DOMUtils.EVENT_LISTENERS] ?? []) {
 			
 			for (const [listener] of listeners) {
 
@@ -307,7 +307,7 @@ function _getOuterHTML(el:Node, opts?:_renderOptions, collectedStylesheets?:stri
 			throw new Error(`Invalid datex-update="onsubmit", no form found`)
 		}
 
-		for (const [attr, ptr] of (<DOMUtils.elWithEventListeners>el)[DOMUtils.PSEUDO_ATTR_BINDINGS] ?? []) {
+		for (const [attr, ptr] of (<DOMUtils.elWithUIXAttributes>el)[DOMUtils.PSEUDO_ATTR_BINDINGS] ?? []) {
 
 			hasScriptContent = true;
 			const propName = attr == "checked" ? "checked" : "value";

--- a/src/html/template.ts
+++ b/src/html/template.ts
@@ -41,7 +41,7 @@ function cloneWithListeners(element: Node) {
 	// cannot use cloneNode(true) because listeners have to be copied for all children
 	const clone = element.cloneNode(false);
 	if (clone instanceof domContext.Element) {
-		for (const [event, listeners] of (<DOMUtils.elWithEventListeners>element)[DOMUtils.EVENT_LISTENERS]??[]) {
+		for (const [event, listeners] of (<DOMUtils.elWithUIXAttributes>element)[DOMUtils.EVENT_LISTENERS]??[]) {
 			for (const [listener] of listeners) {
 				domUtils.setElementAttribute(clone, "on"+event, listener);
 			}

--- a/src/jsx-runtime/jsx.ts
+++ b/src/jsx-runtime/jsx.ts
@@ -6,3 +6,10 @@ const {jsx:_jsx, jsxs:_jsxs, Fragment:_Fragment} = enableJSX(domContext, domUtil
 export const jsx = _jsx;
 export const jsxs = _jsxs;
 export const Fragment = _Fragment;
+
+// make jsx available on globalThis
+Object.defineProperties(globalThis, {
+	_jsx: {value: jsx},
+	_jsxs: {value: jsxs},
+	_Fragment: {value: Fragment},
+})

--- a/src/routing/frontend-routing.ts
+++ b/src/routing/frontend-routing.ts
@@ -85,11 +85,11 @@ export namespace Routing {
 					if (el instanceof HTMLElement && el.hasAttribute("slot")) {
 						const name = el.getAttribute("slot")!
 						slot = querySelector(`frontend-slot[name="${domUtils.escapeHtml(name)}"]`) as HTMLElement;
-						if (!slot) logger.error(`Could not find a matching <frontend-slot name="${name}"/>`);
+						if (!slot) logger.error(`Could not find a matching <frontend-slot name="${name}"/> for frontend entrypoint route`);
 					}
 					else {
 						slot = querySelector("frontend-slot") as HTMLElement;
-						if (!slot) logger.error("Could not find a matching <frontend-slot/>");
+						if (!slot) logger.error("Could not find a matching <frontend-slot/> for frontend entrypoint route");
 					}
 	
 					if (slot) {

--- a/src/runners/run-remote.ts
+++ b/src/runners/run-remote.ts
@@ -1,5 +1,5 @@
 import { normalizedAppOptions } from "../app/options.ts";
-import { stage, env, watch } from "../app/args.ts";
+import { stage, env, watch, clear } from "../app/args.ts";
 import { ESCAPE_SEQUENCES, verboseArg } from "datex-core-legacy/utils/logger.ts";
 import { GitRepo } from "../utils/git.ts";
 import { Path } from "../utils/path.ts";
@@ -72,6 +72,9 @@ export async function runRemote(params: runParams, root_path: URL, options: norm
 	const args = [];
 	if (watch) args.push("--watch");
 	if (verboseArg) args.push("--verbose");
+	if (clear) args.push("--clear");
+
+
 	if (params.inspect!=undefined) {
 		if (params.inspect) args.push(`--inspect=${params.inspect}`);
 		else args.push("--inspect");

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -430,6 +430,7 @@ export class Server {
                 if (datexEndpointNew || !Datex.Supranet.connected) {
                     // endpoint is new and not yet registered in network - cannot validate at this point, no valid session
                     // or not connected to supranet -> cannot validate keys
+                    endpoint = Target.get(datexEndpointCookie) as Datex.Endpoint;
                 }
 
                 // has uix-session - check if still a valid session

--- a/src/server/transpiler.ts
+++ b/src/server/transpiler.ts
@@ -171,8 +171,13 @@ export class Transpiler {
      */
     public async transpileDir(dir: Path.File) {
         const promises = []
+        const maxParallel = 50;
         for await (const e of walk!(dir, {includeDirs: false, exts: this.#transpile_exts.map(x=>'.'+x)})) {
             promises.push(this.updateFile(new Path(e.path), true, true));
+            if (promises.length >= maxParallel) {
+                await Promise.all(promises);
+                promises.length = 0;
+            }
         }
         await Promise.all(promises)
     }

--- a/src/style/base.css
+++ b/src/style/base.css
@@ -6,7 +6,7 @@
     --current_text_color_highlight: var(--text_highlight);
 } */
 
-light-root, uix-fragment, frontend-slot {
+light-root, uix-fragment, uix-placeholder, frontend-slot {
     display: contents;
 }
 

--- a/uix-short.ts
+++ b/uix-short.ts
@@ -18,10 +18,10 @@ import "./src/utils/window-apis.ts";
 export {unsafeHTML} from "./src/html/unsafe-html.ts";
 
 declare global {
-	const content: typeof _content;
+	const ref: typeof _content;
 	const id: typeof _id;
 	const layout: typeof _layout;
-	const child: typeof _child;
+	const value: typeof _child;
 	const NoResources: typeof _NoResources;
 	const frontend: typeof _frontend;
 	const bindOrigin: typeof _bindOrigin;


### PR DESCRIPTION
For non-"dev" stages, native error stack traces are now disabled to prevent the unnecessary exposure of internal information from the backend.
Native error messages are still exposed because they might be used for app logic.