### PR TITLE
Copy nodes and blockchain relay from backend .dx to frontend .dx

### DIFF
--- a/src/server/transpiler.ts
+++ b/src/server/transpiler.ts
@@ -544,7 +544,7 @@ export class Transpiler {
             plugins: [
                 ["jusix", {}]
             ]
-        } : {}
+        } as Record<string, any> : undefined;
 
         const js_dist_path = this.getFileWithMappedExtension(ts_dist_path);
         try {


### PR DESCRIPTION
Related to https://github.com/unyt-org/datex-core-js-legacy/pull/68

With this PR, we can now configure a backend endpoint with a custom relay endpoint and public keys for the relay endpoint (in the backend .dx file):
```dx
blockchain_relay: @+my-relay-node,

nodes: <Map> [
	[
		@+my-relay-node, {
			channels: {websocket: "relay.example.com"},
			keys: [
				`307630103443340...`,
				`308202223600D06...`
			]
		}
	]
]
```

These entries and the additional backend endpoint public keys are now available in the frontend .dx file.

This allows the creation of a complete isolated UIX app setup without the dependency on unyt node infrastructure.