### PR TITLE
Improved remote docker runners

### DIFF
--- a/run.ts
+++ b/run.ts
@@ -25,6 +25,7 @@ import { handleAutoUpdate, updateCache } from "./auto-update.ts";
 import { enableErrorReporting } from "datex-core-legacy/utils/error-reporting.ts";
 import { getErrorReportingPreference, saveErrorReportingPreference, shouldAskForErrorReportingPreference } from "./src/utils/error-reporting-preference.ts";
 import { isCIRunner } from "./src/utils/check-ci.ts";
+import { runParams } from "./src/runners/runner.ts";
 
 const logger = new Datex.Logger("UIX Runner");
 
@@ -91,18 +92,6 @@ Datex.Logger.development_log_level = Datex.LOG_LEVEL.ERROR
 Datex.Logger.production_log_level = Datex.LOG_LEVEL.ERROR
 
 
-
-/**
- * command line params + files
- */
-export type runParams = {
-    reload: boolean | undefined;
-    enableTLS: boolean | undefined;
-    inspect: string | undefined;
-    unstable: boolean | undefined;
-	detach: boolean | undefined;
-    deno_config_path: URL | null;
-}
 
 const isWatching = live || watch_backend;
 

--- a/src/app/args.ts
+++ b/src/app/args.ts
@@ -29,6 +29,7 @@ export const port = command_line_options.option("port", {default: 80, type:"numb
 
 export const enableTLS = command_line_options.option("enable-tls", {type:"boolean", description: "Enable TLS for the HTTP server"});
 
+export const githubToken = command_line_options.option("gh-token", {type:"string", description: "Github token for running in remote location"});
 
 // clear
 export const clear = command_line_options.option("clear", {type:"boolean", description: "Clear all eternal states on the backend"});

--- a/src/app/dx-config-parser.ts
+++ b/src/app/dx-config-parser.ts
@@ -4,6 +4,7 @@ import type { Datex as _Datex } from "datex-core-legacy"; // required by getAppC
 import type {Datex as DatexType} from "datex-core-legacy";
 import { Path } from "../utils/path.ts";
 import { normalizedAppOptions } from "../app/options.ts";
+import { formatEndpointURL } from "../utils/format-endpoint-url.ts";
 
 async function readDXConfigData(path: URL) {
 	const dx = (await Datex.Runtime.getURLContent(path, false, false) ?? {}) as Record<string,any>;
@@ -66,6 +67,13 @@ export async function getDXConfigData(backend: Path, options:normalizedAppOption
 				}
 			}
 		}
+	}
+
+
+	// add unyt.app domain for stageEndpoint
+	if (stageEndpoint && stageEndpoint !== Datex.LOCAL_ENDPOINT) {
+		const endpointURL = formatEndpointURL(stageEndpoint);
+		if (endpointURL) domains[endpointURL] = null;
 	}
 
 	return {

--- a/src/runners/run-local-docker.ts
+++ b/src/runners/run-local-docker.ts
@@ -79,7 +79,7 @@ export default class LocalDockerRunner implements UIXRunner {
 
 	}
 
-	generateDockerComposeFile({baseURL, endpoint, domains}: runOptions, deploymentDir: Path) {
+	generateDockerComposeFile({baseURL, endpoint, domains, params}: runOptions, deploymentDir: Path) {
 		if (!endpoint) throw new Error("Missing in endpoint for stage '" + stage + "' ('"+this.name+"' runner)");
 
 		const name = endpoint.toString().replace(/[^A-Za-z0-9_-]/g,'').toLowerCase()
@@ -98,6 +98,13 @@ export default class LocalDockerRunner implements UIXRunner {
 		if (verboseArg) args.push("-v")
 		if (clear) args.push("--clear");
 
+		const ports = []
+
+		if (params.inspect!=undefined) {
+			args.push("--inspect=0.0.0.0:9229");
+			ports.push(`${params.inspect||'9229'}:${params.inspect||'9229'}`)
+		}
+
 		const dockerCompose = {
 			version: "3",
 
@@ -107,6 +114,7 @@ export default class LocalDockerRunner implements UIXRunner {
 					image: "denoland/deno:1.37.2",
 
 					expose: ["80"],
+					ports,
 	
 					environment: [
 						"UIX_HOST_ENDPOINT=local-docker",

--- a/src/runners/run-local-docker.ts
+++ b/src/runners/run-local-docker.ts
@@ -101,8 +101,9 @@ export default class LocalDockerRunner implements UIXRunner {
 		const ports = []
 
 		if (params.inspect!=undefined) {
-			args.push("--inspect=0.0.0.0:9229");
-			ports.push(`${params.inspect||'9229'}:${params.inspect||'9229'}`)
+			const port = params.inspect||'9229';
+			args.push(`--inspect=0.0.0.0:${port}`);
+			ports.push(`${port}:${port}`)
 		}
 
 		const dockerCompose = {

--- a/src/runners/run-local-docker.ts
+++ b/src/runners/run-local-docker.ts
@@ -1,6 +1,6 @@
 import { json2yaml } from "https://deno.land/x/json2yaml@v1.0.1/mod.ts";
 import { Path } from "../utils/path.ts";
-import { stage, watch } from "../app/args.ts";
+import { clear, stage, watch } from "../app/args.ts";
 import { createHash } from "https://deno.land/std@0.91.0/hash/mod.ts";
 // import { Datex } from "datex-core-legacy/no_init.ts";
 import { UIXRunner, runOptions } from "./runner.ts";
@@ -61,10 +61,11 @@ export default class LocalDockerRunner implements UIXRunner {
 			console.log(ESCAPE_SEQUENCES.GREEN + runOptions.endpoint + (Object.keys(runOptions.domains).length ? ` (${Object.keys(runOptions.domains).map(domain=>`https://${domain}`).join(", ")})` : '') +" is running in local docker container ("+id+")" + ESCAPE_SEQUENCES.RESET);
 			
 			if (runOptions.params.detach || id === "unknown id") {
-				return;
+				Deno.exit(0);
 			}
 		
 			else {
+				
 				await new Deno.Command("docker", {
 					args: [
 						"logs",
@@ -95,6 +96,7 @@ export default class LocalDockerRunner implements UIXRunner {
 		const args = [];
 		if (watch) args.push("--watch");
 		if (verboseArg) args.push("-v")
+		if (clear) args.push("--clear");
 
 		const dockerCompose = {
 			version: "3",

--- a/src/runners/run-remote.ts
+++ b/src/runners/run-remote.ts
@@ -4,8 +4,11 @@ import { ESCAPE_SEQUENCES, verboseArg } from "datex-core-legacy/utils/logger.ts"
 import { GitRepo } from "../utils/git.ts";
 import { Path } from "../utils/path.ts";
 import { runParams } from "./runner.ts";
+import { logger } from "../utils/global-values.ts";
+import { githubToken } from "../app/args.ts";
 
 declare const Datex: any; // cannot import Datex here, circular dependency problems
+type Endpoint = any
 
 // copied from ContainerManager
 enum ContainerStatus {
@@ -74,6 +77,10 @@ export async function runRemote(params: runParams, root_path: URL, options: norm
 	if (verboseArg) args.push("--verbose");
 	if (clear) args.push("--clear");
 
+	// don't log internal verbose messages
+	Datex.Logger.development_log_level = Datex.LOG_LEVEL.ERROR
+	Datex.Logger.production_log_level = Datex.LOG_LEVEL.ERROR
+
 
 	if (params.inspect!=undefined) {
 		if (params.inspect) args.push(`--inspect=${params.inspect}`);
@@ -111,7 +118,7 @@ export async function runRemote(params: runParams, root_path: URL, options: norm
 				${env},
 				${args},
 				${normalizedVolumes},
-				${Deno.env.get("GITHUB_TOKEN")}
+				${githubToken ?? Deno.env.get("GITHUB_TOKEN")}
 			)
 		`
 		// console.log("");
@@ -119,9 +126,10 @@ export async function runRemote(params: runParams, root_path: URL, options: norm
 
 
 		// observe container status and exit
-		Datex.Value.observeAndInit(await datex `${container}->status`, async (status: ContainerStatus) => {
+		const handler = async (status: ContainerStatus) => {
 			// As soon as container is running, keep process alive, show remote container logs
 			if (!params.detach && status == ContainerStatus.RUNNING) {
+				Datex.Value.unobserve(containerStatus, handler);
 				loaded = true;
 				const stream = (await container.getLogs());
 				// @ts-ignore TODO: only workaround, make persistent
@@ -133,49 +141,69 @@ export async function runRemote(params: runParams, root_path: URL, options: norm
 			// As soon as endpoint is online: don't stream logs, close process
 			else if (params.detach && status == ContainerStatus.ONLINE) {
 				loaded = true;
-				console.log(ESCAPE_SEQUENCES.GREEN + stageEndpoint + (Object.keys(customDomains).length ? ` (${Object.keys(customDomains).map(domain=>`https://${domain}`).join(", ")})` : '') +" is running on " + requiredLocation + ESCAPE_SEQUENCES.RESET);
-				Deno.exit(0)
+				logSuccess(stageEndpoint, requiredLocation, customDomains)
 			}
 			else if (status == ContainerStatus.FAILED) {
 				loaded = true;
-				logger.error('❌ Failed to start ' + stageEndpoint + (Object.keys(customDomains).length ? ` (${Object.keys(customDomains).map(domain=>`https://${domain}`).join(", ")})` : '') +" on " + requiredLocation);
-				Deno.exit(1)
+				logFailure(stageEndpoint, requiredLocation, customDomains, container.errorMessage)
 			}
-		})
+		}
+
+		const containerStatus = await datex `${container}->status`;
+
+		Datex.Value.observeAndInit(containerStatus, handler)
 	}
 
 	catch (e) {
-		console.log(e.message);
-		logger.error('❌ Failed to start ' + stageEndpoint + (Object.keys(customDomains).length ? ` (${Object.keys(customDomains).map(domain=>`https://${domain}`).join(", ")})` : '') +" on " + requiredLocation);
-		Deno.exit(1)
+		logFailure(stageEndpoint, requiredLocation, customDomains, e.message)
 	}
-	
 
 }
 
+function logFailure(stageEndpoint: Endpoint, requiredLocation: Endpoint, customDomains: Record<string,number|null> = {}, message?: string) {
+	console.log("");
+	logger.error('❌ Failed to start ' + stageEndpoint + (Object.keys(customDomains).length ? ` (${Object.keys(customDomains).map(domain=>`https://${domain}`).join(", ")})` : '') +" on " + requiredLocation + (message ? `:` : ""));
+	if (message) console.log(message);
+	Deno.exit(1)
+}
+
+function logSuccess(stageEndpoint: Endpoint, requiredLocation: Endpoint, customDomains: Record<string,number|null> = {}) {
+	logger.success(ESCAPE_SEQUENCES.GREEN + stageEndpoint + (Object.keys(customDomains).length ? ` (${Object.keys(customDomains).map(domain=>`https://${domain}`).join(", ")})` : '') +" is running on " + requiredLocation + ESCAPE_SEQUENCES.RESET);
+	Deno.exit(0)
+}
+
+let streaming = false;
+
 function streamLogs(reader: ReadableStreamDefaultReader) {
+
+	if (streaming) return;
+	streaming = true;
+
 	function readStream() {
 		reader.read().then(({ done, value }) => {
 			if (done) {
 				// Stream ended, exit the loop
-				console.log("Stream ended");
-				return;
+				console.log("[Stream was closed]");
+				Deno.exit(0)
 			}
-	  
+	  		if (value instanceof ArrayBuffer) {
+				value = new Uint8Array(value);
+			}
 		  	// Process and print the data
 			if (value instanceof Uint8Array) {
 				Deno.stdout.writeSync(value)
+				// check of EOT character contained in stream
+				if (value.includes(4)) {
+					Deno.exit(0)
+				}
 			}
-			else  if (value instanceof ArrayBuffer) {
-				Deno.stdout.writeSync(new Uint8Array(value))
-			}
-	  		else console.log("invalid stream value", 	value);
+	  		else console.log("[invalid stream value]", value);
 
 		  // Continue reading the stream
 		  readStream();
 		});
-	  }
+	}
 	  
-	  // Start reading the stream
-	  readStream();
+	// Start reading the stream
+	readStream();
 }

--- a/src/runners/runner.ts
+++ b/src/runners/runner.ts
@@ -8,7 +8,7 @@ import { Path } from "../utils/path.ts";
 export type runParams = {
     reload: boolean | undefined;
     enableTLS: boolean | undefined;
-    inspect: boolean | undefined;
+    inspect: string | undefined;
     unstable: boolean | undefined;
 	detach: boolean | undefined;
     deno_config_path: string | URL | null;

--- a/src/utils/format-endpoint-url.ts
+++ b/src/utils/format-endpoint-url.ts
@@ -1,0 +1,8 @@
+import type { Datex } from "datex-core-legacy/mod.ts";
+
+export function formatEndpointURL(endpoint:Datex.Endpoint) {
+	const endpointName = endpoint.toString();
+	if (endpointName.startsWith("@+")) return `${endpointName.replace("@+","")}.unyt.app`
+	else if (endpointName.startsWith("@@")) return `${endpointName.replace("@@","")}.unyt.app`
+	else if (endpointName.startsWith("@")) return `${endpointName.replace("@","")}.unyt.me`
+}


### PR DESCRIPTION
This PR improves UIX app runners:

 * support for docker host error message logs
 * close remote logs streams are handled (process exit)
 * `--inspect` is now supported for local docker runners
 * hosted unyt.app backends are now handled correctly
* you can now also use `--gh-token` instead of an ENV variable to pass a GitHub deployment token.