### PR TITLE
Fix routing issues

### DIFF
--- a/docs/manual/14 Deployment.md
+++ b/docs/manual/14 Deployment.md
@@ -18,7 +18,7 @@ there are two other possible endpoint location types:
 A remote docker host is a special endpoint running on another device (e.g. on a deployment server) that manages
 dockers on the device and can communicate with a UIX app to deploy new docker containers.
 
-Unyt.org provides public docker hosts (`@+app-host-eu2`) that can be used to deploy UIX apps under `unyt.app` domains.
+unyt.org provides public docker hosts (`@+app-host-eu2`) that can be used to deploy UIX apps under `unyt.app` domains.
 
 If you want to set up you own docker host on your server, take a look at the [Docker Host](https://github.com/unyt-org/docker-host/) documentation.
 

--- a/docs/manual/14 Deployment.md
+++ b/docs/manual/14 Deployment.md
@@ -18,13 +18,13 @@ there are two other possible endpoint location types:
 A remote docker host is a special endpoint running on another device (e.g. on a deployment server) that manages
 dockers on the device and can communicate with a UIX app to deploy new docker containers.
 
-Unyt.org provides public docker hosts (`@+unyt_eu1`, `@+unyt_eu2`) that can be used to deploy UIX apps under `unyt.app` domains.
+Unyt.org provides public docker hosts (`@+app-host-eu2`) that can be used to deploy UIX apps under `unyt.app` domains.
 
 If you want to set up you own docker host on your server, take a look at the [Docker Host](https://github.com/unyt-org/docker-host/) documentation.
 
 The following options can be set in a backend `.dx` file to configure a remote docker host.
 
-* `location`: *(endpoint or text)* A docker host endpoint (e.g. `@+unyt_eu1` or a self-hosted endpoint) where the UIX should be hosted. The default is `@@local`, meaning that the app is run locally and not on a docker host.
+* `location`: *(endpoint or text)* A docker host endpoint (e.g. `@+app-host-eu2` or a self-hosted endpoint) where the UIX should be hosted. The default is `@@local`, meaning that the app is run locally and not on a docker host.
 * `domain`: *(text or text[])* One or multiple custom domains on which the web server is listening. This only works if the domain is pointing to the ip address of the docker host.
 * `volumes`: *(url or url[])* Directories that are mapped to persistent docker volumes on the docker host
 
@@ -42,12 +42,12 @@ ssh -L 127.0.0.1:9229:127.0.0.1:9229 YOUR_USERNAME@YOUR_SERVER_DOMAIN
 
 ```datex
 endpoint: @+my_app,
-location: @+unyt_eu1,
+location: @+app-host-eu2,
 volumes:  [../data]
 ```
 
 With this example configuration, every time you start your app by running `uix`,
-it will get deployed on `@+unyt_eu1`.
+it will get deployed on `@+app-host-eu2`.
 
 To still run the app locally during development and
 get a fine-grained control for the behaviour in different stages,
@@ -74,8 +74,8 @@ endpoint: stage {
 // and 'prod'. The default 'dev' stage has no assigned value 
 // and falls back to the default (running locally)
 location: stage {
-    staging:    @+unyt_eu1,
-    prod:       @+unyt_eu2
+    staging:    @+app-host-eu1,
+    prod:       @+app-host-eu2
 }
 ```
 
@@ -99,6 +99,9 @@ Now, you can start your app like always with the `uix` command.
 > [!WARNING]
 > Currently, only the following uix command line arguments are supported when running with 'local-docker'
 > * `--watch`
+> * `--inspect`
+> * `--verbose`
+> * `--clear`
 
 
 ## GitHub deployment

--- a/src/runners/run-local-docker.ts
+++ b/src/runners/run-local-docker.ts
@@ -83,9 +83,10 @@ export default class LocalDockerRunner implements UIXRunner {
 		if (!endpoint) throw new Error("Missing in endpoint for stage '" + stage + "' ('"+this.name+"' runner)");
 
 		const name = endpoint.toString().replace(/[^A-Za-z0-9_-]/g,'').toLowerCase()
-		const traefikLabels = []
+		const traefikLabels = new Set()
+		let i = 0;
 		for (const [host, port] of Object.entries(domains)) {
-			traefikLabels.push(...this.getTraefikLabels(name, host, port))
+			for (const label of this.getTraefikLabels(name + '_' + (i++), host, port)) traefikLabels.add(label)
 		}
 
 		const dxCacheVolumeName = name.replace(/[^a-zA-Z0-9_.-]/g, '-') + '-datex-cache'
@@ -111,7 +112,7 @@ export default class LocalDockerRunner implements UIXRunner {
 			services: {
 				"uix-app": {
 					container_name: `${name}`,
-					image: "denoland/deno:1.37.2",
+					image: "denoland/deno:1.39.4",
 
 					expose: ["80"],
 					ports,
@@ -128,7 +129,7 @@ export default class LocalDockerRunner implements UIXRunner {
 						`${dxCacheVolumeName}:/datex-cache`,
 						`${localStorage}:/deno-dir/location_data`
 					],
-					labels: traefikLabels,
+					labels: [...traefikLabels],
 					
 					entrypoint: "/bin/sh",
 					// keep dev.cdn for now to allow supranet relays to start without cdn running

--- a/src/server/datex_server.ts
+++ b/src/server/datex_server.ts
@@ -309,7 +309,7 @@ class TCPComInterface extends ServerDatexInterface  {
                 }
 
                 /* an other endpoint is reachable over this interface*/
-                if (header && header.sender!=conn_endpoint && !this.reachable_endpoints.has(header.sender)) {
+                if (header && header.sender!=conn_endpoint && !this.reachable_endpoints.has(header.sender)) {
                     this.reachable_endpoints.set(header.sender, conn_endpoint)
                     Datex.CommonInterface.addIndirectInterfaceForEndpoint(header.sender, this)
                 }
@@ -408,7 +408,7 @@ class WebsocketStreamComInterface extends ServerDatexInterface {
                 }
 
                 /* an other endpoint is reachable over this interface*/
-                if (header && header.sender!=ws_stream.endpoint && !this.reachable_endpoints.has(header.sender)) {
+                if (header && header.sender!=ws_stream.endpoint && !this.reachable_endpoints.has(header.sender)) {
                     this.reachable_endpoints.set(header.sender, ws_stream.endpoint)
                     Datex.CommonInterface.addIndirectInterfaceForEndpoint(header.sender, this)
                 }
@@ -487,6 +487,11 @@ class WebsocketComInterface extends ServerDatexInterface {
                 const endpoint = this.socket_endpoints.get(socket)!;
                 this.connected_endpoints.delete(endpoint)
                 this.socket_endpoints.delete(socket)
+                this.endpoints.delete(endpoint)
+                // also remove all reachable endpoints
+                for (const [reachableEndpoint, redirect] of this.reachable_endpoints) {
+                    if (redirect === endpoint) this.reachable_endpoints.delete(reachableEndpoint)
+                }
             }
 
             socket.onclose = dispose
@@ -518,7 +523,7 @@ class WebsocketComInterface extends ServerDatexInterface {
                     }, proxySource)
                 }
                 else {
-                    header = await this.handleBlock(new Uint8Array(dmx_block).buffer, this.socket_endpoints.get(socket), null, proxySource)
+                    header = await this.handleBlock(new Uint8Array(dmx_block).buffer, this.socket_endpoints.get(socket)!, undefined, proxySource)
                 }
 
                 /* an other endpoint is reachable over this interface*/
@@ -587,6 +592,11 @@ class WebsocketComInterface extends ServerDatexInterface {
             catch (e) {
                 this.socket_endpoints.delete(connectedEndpointSocket);
                 this.connected_endpoints.delete(to);
+                this.endpoints.delete(to)
+                // also remove all reachable endpoints
+                for (const [reachableEndpoint, redirect] of this.reachable_endpoints) {
+                    if (redirect === to) this.reachable_endpoints.delete(reachableEndpoint)
+                }
                 // console.log("Socket Error sending to " + to, e);
             }
         }


### PR DESCRIPTION
Another attempt to fix the well known `@+unyt2 is offline` issue.
I could track the issue (or at least one scenario) down to a routing issue where `@+unyt2` tries to use an outdated (closed) socket connection to send a DATEX RESPONSE back to the requesting endpoint. This leads to a DATEX timeout and offline state.