### PR TITLE
Improve protected rendering

### DIFF
--- a/src/app/frontend-manager.ts
+++ b/src/app/frontend-manager.ts
@@ -795,6 +795,7 @@ if (!window.location.origin.endsWith(".unyt.app")) {
 	 * @returns 
 	 */
 	public async getEntrypointContent(entrypoint: Entrypoint, path?: string, lang = 'en', context?:ContextGenerator|Context): Promise<[content:[string,string]|string|raw_content|null, render_method:RenderMethod, status_code?:number, open_graph_meta_tags?:OpenGraphInformation|undefined, headers?:Headers, contentElement?: Element|DocumentFragment, requiredPointers?:Set<Node>]> {
+		
 		// extract content from provider, depending on path
 		const {content, render_method, status_code, headers} = await resolveEntrypointRoute({
 			entrypoint: entrypoint,

--- a/src/html/render.ts
+++ b/src/html/render.ts
@@ -34,7 +34,7 @@ type _renderOptions = {
 	_injectedJsData?:injectScriptData, 
 	lang?:string, 
 	allowIgnoreDatexFunctions?: boolean,
-	hydratableNodes?: Set<Node>,
+	requiredPointers?: Set<any>,
 }
 
 export const CACHED_CONTENT = Symbol("CACHED_CONTENT");
@@ -240,7 +240,7 @@ function _getOuterHTML(el:Node, opts?:_renderOptions, collectedStylesheets?:stri
 
 	// hydratable
 	if (isLiveNode(el)) {
-		if (opts?.hydratableNodes) opts.hydratableNodes.add(el);
+		if (opts?.requiredPointers) opts.requiredPointers.add(el);
 		attrs.push("uix-dry");
 	}
 	// just static
@@ -272,6 +272,7 @@ function _getOuterHTML(el:Node, opts?:_renderOptions, collectedStylesheets?:stri
 
 				// special form "action" on submit (no js required)
 				if (event == "submit" && Datex.Pointer.getByValue(listenerFn)) {
+					opts?.requiredPointers?.add(listenerFn);
 					attrs.push(`action="/@uix/form-action/${Datex.Pointer.getByValue(listenerFn)!.idString()}/"`);
 				} 
 
@@ -309,6 +310,8 @@ function _getOuterHTML(el:Node, opts?:_renderOptions, collectedStylesheets?:stri
 
 		for (const [attr, ptr] of (<DOMUtils.elWithUIXAttributes>el)[DOMUtils.PSEUDO_ATTR_BINDINGS] ?? []) {
 
+			opts?.requiredPointers?.add(ptr);
+			
 			hasScriptContent = true;
 			const propName = attr == "checked" ? "checked" : "value";
 			const keepAlive = datexUpdateType == "onsubmit"
@@ -479,7 +482,7 @@ export function getOuterHTML(el:Element|DocumentFragment, opts?:{
 	injectStandaloneComponents?: boolean, 
 	allowIgnoreDatexFunctions?: boolean, 
 	lang?:string, 
-	hydratableNodes?: Set<Node>
+	requiredPointers?: Set<any>
 }): [header_script:string, html_content:string] {
 
 	if ((el as any)[CACHED_CONTENT]) return (el as any)[CACHED_CONTENT];

--- a/src/routing/context.ts
+++ b/src/routing/context.ts
@@ -11,7 +11,7 @@ export type RequestData = {address:string|null}
 
 
 // persistent data
-const privateData = await Datex.Storage.loadOrCreate("UIX.privateData", () => $$(new StorageMap<Endpoint, Record<string, unknown>>()))
+const privateData = await Datex.Storage.loadOrCreate("UIX.privateData", () => new StorageMap<Endpoint, Record<string, unknown>>())
 const emptyMatch = Object.freeze({});
 
 


### PR DESCRIPTION
Currently, pointers cannot be updated via datex-over-http when `PROTECT_POINTERS` is enabled.
UIX now automatically adds all pointer dependencies to the access list.
Pointer properties are also supported, but currently the access is granted for the whole pointer, not just for the property