### PR TITLE
Unify Error Logging and Migrate Base Project Initialization to Deno 2.0

### DIFF
--- a/run.ts
+++ b/run.ts
@@ -28,6 +28,7 @@ import { getErrorReportingPreference, saveErrorReportingPreference, shouldAskFor
 import { isCIRunner } from "./src/utils/check-ci.ts";
 import { logger, runParams } from "./src/runners/runner.ts";
 import { applyPlugins } from "./src/app/config-files.ts";
+import { handleError } from "./src/utils/handle-issue.ts";
 
 // catch unhandledrejections
 enableUnhandledRejectionHandler(logger);
@@ -35,17 +36,15 @@ enableUnhandledRejectionHandler(logger);
 // login flow
 if (login) await triggerLogin();
 // init
-if (init!=undefined) {
+if (init != undefined) {
 	if (rootPath) {
-		logger.error("A UIX Project already exists in this location");
-		Deno.exit(1);
+		handleError("A UIX Project exists already in this location", logger);
 	}
 	else await initBaseProject(init);
 }
 
 // allow unyt.org diagnostics?
 if (stage === "dev") {
-
 	try {
 		let allow = false;
 		

--- a/src/utils/handle-issue.ts
+++ b/src/utils/handle-issue.ts
@@ -18,8 +18,10 @@ const ESCAPE_SEQUENCE_NORMAL_INTENSITY = "\x1b[22m";
  * @param [exit=true] Specifies whether the process should exit, defaults to `true`
  * @param [exitCode=1] Code to exit with if `exit` is set to true, defaults to `1`
  */
-export async function handleError(error: Error, logger: Datex.Logger, exit = true, exitCode = 1) {
-	if (error instanceof KnownError) {
+export async function handleError(error: Error|string, logger: Datex.Logger, exit = true, exitCode = 1) {
+	if (typeof error === "string" || error instanceof String) {
+		logger.error(error);
+	} else if (error instanceof KnownError) {
 		if (error.solutions.length > 0) {
 			logger.info(`Suggested Problem Solutions\n${error.solutions.map(s => `- ${s}`).join("\n")}`);
 			console.log();


### PR DESCRIPTION
Unified error messages to be presented using `handleError()`. The deprecated `Deno.run` was replaced in favor of `Deno.Command` which is the way to move forward with Deno 2.0.

Fixes #145 .