### PR TITLE
Disable backend response fetching for legacy frontend router

### DIFF
--- a/src/routing/frontend-routing.ts
+++ b/src/routing/frontend-routing.ts
@@ -228,82 +228,9 @@ export namespace Routing {
 	}
 
 	async function resolveCurrentRoute(allowReload=true){
-		let content:any;
-		let entrypoint:Entrypoint|undefined;
-
-		// TODO: this does not work with frontend slots! content must always first be backend rendered
-		// first check if we can guarantee that the frontend route exists (might still be blocked by a backend route, but this is the
-		// best tradeoff for now)
-		// const frontendRouteExists = await getContentFromEntrypoint(frontend_entrypoint, getCurrentRouteFromURL(), true)
-		// if (frontendRouteExists !== null) {
-		// 	({content, entrypoint} = await resolveCurrentRouteFrontend());
-		// 	if (content !== null) {
-		// 		setContent(content, entrypoint!);
-		// 		return true;
-		// 	}
-		// }
-
-		// try to load backend route content
-		const backendResponse = await fetch(getCurrentRouteFromURL().routename, {
-			credentials: "include",
-			cache: "no-store",
-			headers: {
-				'UIX-Inline-Backend': 'true' // prevent duplicate loading of importmap (leads to errors)
-			}
-		})
-
-		// handle redirect (does not matter if response ok or not)
-		if (backendResponse.redirected) setCurrentRoute(backendResponse.url, true);
-
-		// load backend content
-		if (backendResponse.ok) {
-			// is supported mime type for frontend rendering?
-			if (isContentType(backendResponse, "text/html") || isContentType(backendResponse, "text/plain")) {
-				content = backendResponse
-			}
-			// reload window to correctly display backend response
-			// TODO: better solution?
-			else {
-				window.location.reload()
-			}
-		}
-
-		else {
-			({content, entrypoint} = await resolveCurrentRouteFrontend());
-		}
-
-		setContent(content, entrypoint!);
-		return true;
-
-		// // try backend entrypoint
-		// if (content == null && backend_entrypoint) {
-		// 	content = await getContentFromEntrypoint(backend_entrypoint);
-		// 	entrypoint = backend_entrypoint;
-		// }
-		// if (!frontend_entrypoint && !backend_entrypoint) {
-		// 	const inferred_entrypoint = getInferredDOMEntrypoint();
-		// 	const _content = await getContentFromEntrypoint(inferred_entrypoint);
-		// 	const refetched_route = await refetchRoute(getCurrentRouteFromURL(), inferred_entrypoint);
-			
-		// 	// check of accepted route matches new calculated current_route
-		// 	if (!Path.routesAreEqual(getCurrentRouteFromURL(), refetched_route)) {
-		// 		logger.warn `invalid route from inferred frontend entrypoint, reloading page from backend`; 
-		// 		if (allowReload) window?.location?.reload?.()
-		// 		return false
-		// 	}
-		// 	// window.location.reload()
-		// 	return true;
-		// 	// TODO: what to do with returned content (full entrypoint route not known)
-		// }
-
-		// // still nothing found - route could not be fully resolved on frontend, try to reload from backend
-		// if (content == null) {
-		// 	logger.warn `no content for ${getCurrentRouteFromURL().routename}, reloading page from backend`; 
-		// 	if (allowReload) window?.location?.reload?.()
-		// 	return false;
-		// }
-
-		// await setContent(content, entrypoint!);
+		// fix: disable backend response fetching completely
+		if (!allowReload) console.warn("ignoring allowReload=false, reloading page");
+		window.location.reload();
 	}
 
 	function getInferredDOMEntrypoint(){


### PR DESCRIPTION
This fixes page rendering errors when trying to display HTML fetched from the backend - instead, the page will always just be reloaded.