### PR TITLE
Resolve pinned library versions for frontend importmaps

### DIFF
--- a/src/html/html-provider.ts
+++ b/src/html/html-provider.ts
@@ -44,7 +44,8 @@ export class HTMLProvider {
 		return Path.pathIsURL(path) ? path.toString() : import.meta.resolve(path)
 	}
 
-	getRelativeImportMap() {
+	async getRelativeImportMap() {
+		await this.app_options.import_map.init();
 		const import_map = {imports: {...this.app_options.import_map.static_imports}};
 
 		for (const [key, value] of Object.entries(import_map.imports)) {

--- a/src/html/render.ts
+++ b/src/html/render.ts
@@ -814,7 +814,7 @@ export async function generateHTMLPage({
 	}
 
 	// TODO: add condition if (add_importmap), when polyfill for declarative shadow root is no longer required
-	if (includeImportMap) metaScripts += `<script type="importmap">\n${JSON.stringify(provider.getRelativeImportMap(), null, 4)}\n</script>`;
+	if (includeImportMap) metaScripts += `<script type="importmap">\n${JSON.stringify(await provider.getRelativeImportMap(), null, 4)}\n</script>`;
 	
 	let global_style = '';
 	// stylesheets


### PR DESCRIPTION
This PR fixes frontend caching issues by always providing the resolved module URLs for the frontend importmap, if possible.

Examples:
* `"https://cdn.unyt.org/datex-core-js-legacy@0.1.x/datex.ts"` gets resolved to `"https://cdn.unyt.org/datex-core-js-legacy@0.1.20/datex.ts"`
* `"https://cdn.unyt.org/datex-core-js-legacy/datex.ts"` gets resolved to `"https://cdn.unyt.org/datex-core-js-legacy@0.1.20/datex.ts"`
* `"https://cdn.unyt.org/datex-core-js-legacy/0.1.19/datex.ts"` stays the same