### PR TITLE
Pass deno config path to deno check

### DIFF
--- a/src/runners/run-local.ts
+++ b/src/runners/run-local.ts
@@ -326,9 +326,13 @@ async function checkTSCode(root_path: URL) {
 
 
 async function getCodeStatus(root_path: URL) {
+	const denoConfigPath = new Path(root_path).getChildPath("deno.json").normal_pathname;
+
 	const command = new Deno.Command(Deno.execPath(), {
 		args: [
 			'check',
+			'--config',
+			denoConfigPath,
 			'--allow-import',
 			new Path(root_path).normal_pathname,
 		]


### PR DESCRIPTION
This allow running the uix runner from a different directory than the actual uix project, required for `uix --init`
https://github.com/unyt-org/uix/issues/233