### PR TITLE
Fix: absolute file paths are resolved to local paths when backend-rendering

### DIFF
--- a/src/base/theme-manager.ts
+++ b/src/base/theme-manager.ts
@@ -166,7 +166,12 @@ class ThemeManager  {
 	public registerTheme(theme: Theme) {
 		if (theme.stylesheets) {
 			const dir = getCallerDir();
-			theme.stylesheets = theme.stylesheets.map(s => new Path(s, dir))
+			theme.stylesheets = theme.stylesheets.map(
+				s => new Path(
+					s, 
+					s.toString().startsWith("/") && client_type == "browser" ? globalThis.location.origin : dir
+				)
+			)
 		}
 		this.#loadedThemes.set(theme.name, theme);
 		this.addGlobalThemeClass(theme);
@@ -510,7 +515,10 @@ class ThemeManager  {
 		for (const [key, value] of Object.entries(overrideValues)) {
 			override.values![key] = value;
 		}
-		override.stylesheets = [...(theme.stylesheets??[]), ...(override.stylesheets?.map(s => new Path(s, dir))??[])]
+		override.stylesheets = [...(theme.stylesheets??[]), ...(override.stylesheets?.map(s => new Path(
+			s,
+			s.toString().startsWith("/") && client_type == "browser" ? globalThis.location.origin : dir
+		))??[])]
 		
 		return override as Theme;
 	}

--- a/src/html/render.ts
+++ b/src/html/render.ts
@@ -855,7 +855,7 @@ export async function generateHTMLPage({
 	const themeStylesheets = UIX.Theme.getAllStyleSheets();
 	const stylesheetsAttrs:Record<string, string[]> = {};
 	for (const [name, stylesheets] of themeStylesheets) {
-		stylesheetsAttrs[name] = stylesheets;
+		stylesheetsAttrs[name] = stylesheets.map(s => provider.resolveImport(s, true));
 	}
 	global_style += `<style class="uix-themes" data-stylesheets="${encodeURI(JSON.stringify(stylesheetsAttrs))}">`
 	global_style += UIX.Theme.getThemesCSS().replaceAll("\n","");


### PR DESCRIPTION
Bug Report: https://github.com/unyt-org/uix/issues/239

Fixes a bug introduced in UIX 0.4.10 that leads to theme stylesheets to be interpreted as local file paths instead of web paths when using backend-rendering.