### PR TITLE
Enhance STDOUT and STDERR Processing and Fix Deno Freezes on UIX Restarts

### DIFF
--- a/src/app/start-app.ts
+++ b/src/app/start-app.ts
@@ -8,6 +8,7 @@ import { FrontendManager } from "./frontend-manager.ts";
 import { Path } from "datex-core-legacy/utils/path.ts";
 import { convertToWebPath } from "./convert-to-web-path.ts";
 import { getDirType } from "./utils.ts";
+import { abortFiltering } from "../utils/stdout-filter.ts";
 import { WebSocketServerInterface } from "datex-core-legacy/network/communication-interfaces/websocket-server-interface.ts"
 import { HTTPServerInterface } from "datex-core-legacy/network/communication-interfaces/http-server-interface.ts"
 import { communicationHub } from "datex-core-legacy/network/communication-hub.ts";
@@ -28,6 +29,7 @@ export async function startApp(app: {domains:string[], hostDomains: string[], op
 
 	const frontends = new Map<string, FrontendManager>()
 
+	abortFiltering();
 	StatusBar.sideMessage = "Backend Initializing (30%)";
 	const [nOptions, baseURL] = await normalizeAppOptions(options, original_base_url);
 

--- a/src/runners/reactive-index-generation.ts
+++ b/src/runners/reactive-index-generation.ts
@@ -25,7 +25,7 @@ Deno.mkdirSync(metadataDir, {recursive: true})
 export async function generateReactiveIndices(rootPath: URL, options: normalizedAppOptions, watch: boolean, loadDependencies = true): Promise<{ update: () => Promise<void> }> {
 	if (!options.import_map.path) throw new Error("Import map path must be defined")
 
-	if (loadDependencies) await cacheDependencies();
+	if (loadDependencies) await cacheDependencies(options.import_map.path);
 
 	// get all modules
 	const modulePaths = [];
@@ -35,7 +35,7 @@ export async function generateReactiveIndices(rootPath: URL, options: normalized
 
 	return await generateReactiveIndicesForModules(
 		modulePaths,
-		options.import_map.path.toString(),
+		options.import_map.path,
 		options.import_map.imports,
 		watch
 	)
@@ -43,14 +43,14 @@ export async function generateReactiveIndices(rootPath: URL, options: normalized
 
 // make sure all required depencency modules are cached locally by Deno
 // TODO: this works for known dependencies (e.g. template.ts), but not all remote dependencies are cached or up to date - this is definitely a problem
-async function cacheDependencies() {
+async function cacheDependencies(importMapPath: Path) {
 	const templatePath = new Path("../html/template.ts", import.meta.url);
-	await TSXTypeInferenceGenerator.cacheDependencies([templatePath])
+	await TSXTypeInferenceGenerator.cacheDependencies([templatePath], importMapPath)
 }
 
 async function generateReactiveIndicesForModules(
 	modulePaths: string[],
-	importMapPath: string,
+	importMapPath: Path,
 	imports: Record<string, string>,
 	watch: boolean,
 ): Promise<{ update: () => Promise<void> }> {

--- a/src/runners/run-local.ts
+++ b/src/runners/run-local.ts
@@ -8,7 +8,7 @@ import { generateReactiveIndices } from "./reactive-index-generation.ts";
 import { CTRLSEQ, CSI, StatusBar, StatusType } from "../utils/logging.ts";
 import { isDenoForUIX } from "../utils/version.ts";
 import { handleError, KnownError } from "datex-core-legacy/utils/error-handling.ts";
-import { filterOutputStream } from "../utils/stdout-filter.ts";
+import { filterStream, filterStreamToCallback } from "../utils/stdout-filter.ts";
 
 import  { toText } from "jsr:@std/streams@1.0.12";
 
@@ -221,8 +221,8 @@ export async function runLocal(params: runParams, root_path: URL, options: norma
 
 		process = command.spawn();
 		const outputFilterAbortController = new AbortController();
-		ReadableStream.from(filterOutputStream(process.stdout)).pipeTo(Deno.stdout.writable, { preventClose: true, signal: outputFilterAbortController.signal });
-		ReadableStream.from(filterOutputStream(process.stderr)).pipeTo(Deno.stderr.writable, { preventClose: true, signal: outputFilterAbortController.signal });
+		filterStreamToCallback(process.stdout, (chunk) => Deno.stdout.writeSync(chunk));
+		filterStreamToCallback(process.stderr, (chunk) => Deno.stderr.writeSync(chunk));
 
 		// detach, continues in background
 		// TODO: fix child process does not keep running correctly
@@ -240,9 +240,9 @@ export async function runLocal(params: runParams, root_path: URL, options: norma
 		// CTRL+R
 		if (exitStatus.code == 420) {
 			console.log("CTRL+R pressed, restarting backend...");
+			outputFilterAbortController.abort();
 			try {
 				process.kill();
-				outputFilterAbortController.abort();
 			}
 			catch {
 				// ignore
@@ -368,8 +368,7 @@ async function getCodeStatus(root_path: URL) {
 	});
 
 	const process = command.spawn();
-	const stderr = ReadableStream.from(filterOutputStream(process.stderr));
-
+	const stderr = ReadableStream.from(filterStream(process.stderr));
 	return {
 		valid: (await process.status).code === 0,
 		// remove preamble from error output
@@ -377,9 +376,3 @@ async function getCodeStatus(root_path: URL) {
 		stderr: (await toText(stderr)).replace(/^(.|\n)*?(?=\x1b\[0m\x1b\[1m)/, "")
 	}
 }
-
-async function streamToString(stream: ReadableStream<Uint8Array>): Promise<string> {
-	const response = new Response(stream);
-	return await response.text();
-  }
-  

--- a/src/tsx-type-inference/generator.ts
+++ b/src/tsx-type-inference/generator.ts
@@ -8,7 +8,7 @@ import { sha256 } from "./sha256.js";
 import { Path } from "datex-core-legacy/utils/path.ts";
 import { handleError, KnownError } from "datex-core-legacy/utils/error-handling.ts";
 import { StatusBar } from "../utils/logging.ts";
-import { filterOutputStream } from "../utils/stdout-filter.ts";
+import { filterStreamToCallback } from "../utils/stdout-filter.ts";
 
 export type TypeInferenceOptions = {
 	/**
@@ -122,7 +122,7 @@ export class TSXTypeInferenceGenerator {
 			stderr: "piped",
 		});
 		const process = command.spawn();
-		ReadableStream.from(filterOutputStream(process.stderr)).pipeTo(Deno.stderr.writable, { preventClose: true });
+		filterStreamToCallback(process.stderr, (chunk) => Deno.stderr.writeSync(chunk));
 		
 		const { success } = await process.status;
 		if (!success) {

--- a/src/tsx-type-inference/generator.ts
+++ b/src/tsx-type-inference/generator.ts
@@ -31,7 +31,7 @@ export type TypeInferenceOptions = {
 	/**
 	 * Path to the import map file
 	 */
-	importMapPath?: string,
+	importMapPath?: Path,
 	/**
 	 * jsxImportSource compiler option
 	 */
@@ -102,7 +102,7 @@ export class TSXTypeInferenceGenerator {
 
 		// cache missing dependencies
 		if (this.#unresolvedFiles.size > 0 && tryCache) {
-			await TSXTypeInferenceGenerator.cacheDependencies([...this.#unresolvedFiles]);
+			await TSXTypeInferenceGenerator.cacheDependencies([...this.#unresolvedFiles], this.#options.importMapPath!);
 			this.#unresolvedFiles.clear();
 			// completely reset watch program
 			if (this.#options.watch) {
@@ -115,10 +115,12 @@ export class TSXTypeInferenceGenerator {
 		return positions;
 	}
 
-	public static async cacheDependencies(dependencies: (URL|string)[]) {
+
+	public static async cacheDependencies(dependencies: (URL|string)[], importMapPath: Path) {
+
 		StatusBar.sideMessage = `Downloading ${dependencies.length} ${ dependencies.length == 1 ? "dependency" : "dependencies" } into cache...`;
 		const command = new Deno.Command(Deno.execPath(), {
-			args: ["cache", "-I", ...dependencies.map((dep) => dep.toString())],
+			args: ["cache", "--import-map", importMapPath!.normal_pathname, "-I", ...dependencies.map((dep) => dep.toString())],
 			stderr: "piped",
 		});
 		const process = command.spawn();
@@ -268,7 +270,7 @@ export class TSXTypeInferenceGenerator {
 			// if path is relative, resolve
 			if (resolvedPath.startsWith("./") || resolvedPath.startsWith("../")) {
 				if (!this.#options.importMapPath) throw new Error("importMapPath required for relative paths");
-				const importMapPath = this.#options.importMapPath.startsWith("file://") ? this.#options.importMapPath : 'file://' + this.#options.importMapPath;
+				const importMapPath = this.#options.importMapPath.toString().startsWith("file://") ? this.#options.importMapPath.toString() : 'file://' + this.#options.importMapPath.toString();
 				resolvedPath = new Path(resolvedPath, importMapPath).toString();
 			}
 			const res = new Path("./" + moduleName.replace(firstPart, ""), resolvedPath);

--- a/src/utils/stdout-filter.ts
+++ b/src/utils/stdout-filter.ts
@@ -3,6 +3,7 @@ const PATTERNS: Pattern[] = [
 	{ includes: "Warning The following packages contained npm lifecycle scripts" },
 	{ includes: "Warning the configuration file" },
 	{ includes: "Resolver diagnostics:" },
+	{ includes: "Lifecycle scripts are only supported when using a `node_modules` directory" },
 	{ statusStartsWith: "Download https://" }
 ];
 
@@ -13,7 +14,18 @@ type Pattern = {
 	includes?: string
 };
 
-export async function* filterOutputStream(stream: ReadableStream<Uint8Array>, allowStatusFormatting = true) {
+/**
+ * Async generator that filters a {@link ReadableStream}, given a set of patterns.
+ * Outputs unfiltered chunks once the {@link ABORT_CODE} is encountered.
+ * @param stream The input stream
+ * @param [allowStatusFormatting] Whether to allow grouping status-classified messages together
+ * @param [patterns] A set of patterns to match, uses standard set of {@link PATTERNS} by defalt
+ */
+export async function* filterStream(
+	stream: ReadableStream<Uint8Array>,
+	allowStatusFormatting = true,
+	patterns = PATTERNS
+) {
 	const decoder = new TextDecoder();
 	const encoder = new TextEncoder();
 	let statusModeActive = false;
@@ -22,7 +34,7 @@ export async function* filterOutputStream(stream: ReadableStream<Uint8Array>, al
 		// deno-lint-ignore no-control-regex
 		const text = rawText.replaceAll(/\u001b\[.*?m/g, "");
 		// console.log("OUT", text)
-		for (const pattern of PATTERNS) {
+		for (const pattern of patterns) {
 			if ("matches" in pattern) {
 				if (pattern.matches instanceof RegExp && pattern.matches.test(text)) continue streaming;
 				else if (typeof pattern.matches === "string" && pattern.matches === text) continue streaming;
@@ -43,6 +55,40 @@ export async function* filterOutputStream(stream: ReadableStream<Uint8Array>, al
 		if (statusModeActive) {
 			statusModeActive = false;
 			yield encoder.encode("\n" + rawText);
-		} else yield chunk;
+		} else {
+			yield chunk;
 	}
+	}
+}
+
+/**
+ * Filters a {@link ReadableStream} and calls a callback for each chunk.
+ * Outputs unfiltered chunks once the {@link ABORT_CODE} is encountered.
+ * Invokes {@link filterStream} to process the input.
+ * 
+ * 
+ * @param stream The input stream
+ * @param onChunk If specified, called whenver a chunk passed the filter successfully
+ * @param [allowStatusFormatting] Whether to allow grouping status-classified messages together
+ * @param [patterns] A set of patterns to match, uses standard set of {@link PATTERNS} by defalt
+ */
+export async function filterStreamToCallback(
+	stream: ReadableStream<Uint8Array>,
+	onChunk: (chunk: Uint8Array) => void,
+	allowStatusFormatting = true,
+	patterns = PATTERNS
+) {
+	for await (const chunk of filterStream(stream, allowStatusFormatting, patterns)) {
+		onChunk(chunk);
+	}
+}
+
+/**
+ * When a subprocess' output is piped and filtered through {@link filterStream},
+ * the subprocess can call this function to emit an {@link ABORT_CODE} on stdout and stderr.
+ * This will cause the parent process to let all output pass through without filtering.
+ */
+export function abortFiltering() {
+	Deno.stdout.writeSync(new TextEncoder().encode(ABORT_CODE));
+	Deno.stderr.writeSync(new TextEncoder().encode(ABORT_CODE));
 }

--- a/src/utils/stdout-filter.ts
+++ b/src/utils/stdout-filter.ts
@@ -7,6 +7,8 @@ const PATTERNS: Pattern[] = [
 	{ statusStartsWith: "Download https://" }
 ];
 
+const ABORT_CODE = "\u001b4";
+
 type Pattern = {
 	statusStartsWith?: string,
 	matches?: string | RegExp,
@@ -29,8 +31,16 @@ export async function* filterStream(
 	const decoder = new TextDecoder();
 	const encoder = new TextEncoder();
 	let statusModeActive = false;
+	let aborted = false;
+
 	streaming: for await (const chunk of stream) {
 		const rawText = decoder.decode(chunk);
+		if (aborted || rawText.includes(ABORT_CODE)) {
+			aborted = true;
+			yield chunk;
+			continue;
+		}
+
 		// deno-lint-ignore no-control-regex
 		const text = rawText.replaceAll(/\u001b\[.*?m/g, "");
 		// console.log("OUT", text)
@@ -57,7 +67,7 @@ export async function* filterStream(
 			yield encoder.encode("\n" + rawText);
 		} else {
 			yield chunk;
-	}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR introduces an `ABORT_CODE` signal in the `stdout-filter.ts` which can be printed by subprocesses to indicate that they do not wish to have their output filtered. The abort code is set to `ESC 4` which is an ANSI Escape Code of type "Fp", meaning that it's in private-use area. I have not seen this specific code used on any terminals or terminal emulators for something else.

This PR also fixes a problem that was introduced with #246 where UIX / Deno freezes once the user attempts to restart the server.